### PR TITLE
#14  投稿の詳細表示機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 
-gem 'font-awesome-sass', '~> 5.12.0'
+gem 'font-awesome-sass'
 gem 'jquery-rails'
 
 gem 'sorcery', '0.16.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   carrierwave
-  font-awesome-sass (~> 5.12.0)
+  font-awesome-sass
   jbuilder (~> 2.7)
   jquery-rails
   listen (~> 3.3)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,7 @@
-@import "font-awesome-sprockets";
-@import "font-awesome";
+$fa-font-path: '@fortawesome/fontawesome-free/webfonts';
+@import '@fortawesome/fontawesome-free/scss/fontawesome';
+@import '@fortawesome/fontawesome-free/scss/solid';
+@import '@fortawesome/fontawesome-free/scss/regular';
+@import '@fortawesome/fontawesome-free/scss/brands';
+@import '@fortawesome/fontawesome-free/scss/v4-shims';
+

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,7 +20,7 @@ class PostsController < ApplicationController
   end
 
   def show
-    @board = Board.find(params[:id])
+    @post = Post.find(params[:id])
   end
 
   private

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,6 +3,7 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
+import '@fortawesome/fontawesome-free/js/all'
 import Rails from "@rails/ujs"
 import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"

--- a/app/views/posts/_crud_menus.html.erb
+++ b/app/views/posts/_crud_menus.html.erb
@@ -1,0 +1,12 @@
+<ul class='crud-menu-btn list-inline float-right'>
+  <li class="list-inline-item">
+    <%= link_to '#', id: "button-edit-#{post.id}" do %>
+      <%= icon 'fa', 'pen' %>
+    <% end %>
+  </li>
+  <li class="list-inline-item">
+    <%= link_to '#', id: "button-delete-#{post.id}" do %>
+      <%= icon 'fas', 'trash' %>
+    <% end %>
+  </li>
+</ul>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,7 +2,7 @@
   <div id="board-id-<%= post.id %>">
     <div class="card">
       <a href="#">
-        <%= image_tag post.post_image_url, class: 'card-img-top', size: '300x200' %>
+        <%= link_to (image_tag post.post_image_url, class: 'card-img-top', size: '300x200'),post_path(post) %>
       </a>
       <div class="card-body">
         <h4 class="card-title">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,25 @@
+<div class="container pt-5">
+  <div class="row mb-3">
+    <div class="col-lg-8 offset-lg-2">
+      <h1><%= t('.title') %></h1>
+      <!-- 掲示板内容 -->
+      <article class="card">
+        <div class="card-body">
+          <div class='row'>
+            <div class='col-md-3'>
+              <%= image_tag @post.post_image.url, class: 'card-img-top img-fluid', size: '300x200' %>
+            </div>
+            <div class='col-md-9'>
+              <h3 class="d-inline"><%= @post.budget %></h3>
+              <%= render 'crud_menus', post: @post %>
+              <ul class="list-inline">
+                <li class="list-inline-item">by <%= @post.user.name %></li>
+                <li class="list-inline-item"><%= l @post.created_at, format: :long  %></li>
+              </ul>
+            </div>
+          </div>
+          <%= simple_format(@post.body) %>
+        </div>
+      </article>
+    </div>
+  </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -33,6 +33,8 @@ ja:
       title: '投稿作成'
       budget: '予算'
       body: '本文'
+    show:
+      title: '詳細画面'
     bookmarks:
       title: 'お気に入り一覧'
   profiles:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
-  resources :posts, only: %i[new create]
+  resources :posts, only: %i[new create show]
 end

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "runteq-pf01",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.2.1",
     "@popperjs/core": "^2.11.6",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -917,6 +917,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@fortawesome/fontawesome-free@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-6.2.1.tgz#344baf6ff9eaad7a73cff067d8c56bfc11ae5304"
+  integrity sha512-viouXhegu/TjkvYQoiRZK3aax69dGXxgEjpvZW81wIJdxm5Fnvp3VVIP4VHKqX4SvFw6qpmkILkD4RJWAdrt7A==
+
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"


### PR DESCRIPTION
・投稿の詳細表示機能を追加しました。

1. routesの設定
2. viewの追加
3. 編集、削除をアイコン表示させるためにfont_awesomeの追加
4. 編集、削除ボタンを表示する部分テンプレートの作成
5. 投稿一覧画面の画像をクリックした際に、詳細画面へと飛ぶようにパスの設定

現状表示されるのは以下の種類になる。
1. 画像
2. 予算
3. 説明文
4. 投稿者の名前
5. 投稿した日付