### PR TITLE
config/storage.ymlのインデントを修正

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,7 +7,7 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
- amazon:
+amazon:
   service: S3
   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>


### PR DESCRIPTION
・herokuにデプロイ後、インデントでエラーが発生したので修正しました。