### PR TITLE
action mailerの本番環境の設定を追加しました。

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
+  default from: ENV['SENDER_ADDRESS']
+  layout "mailer"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,12 +63,27 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "runteq_PF01_production"
 
-  config.action_mailer.perform_caching = false
+  #config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = Settings.default_url_options.to_h
+
+  config.action_mailer.default_url_options = { host: 'https://runteq-snow-board.herokuapp.com' }
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.default :charset => "utf-8"
+  # Gmail の場合
+  config.action_mailer.smtp_settings = {
+  :enable_starttls_auto => true,
+  :address => "smtp.gmail.com",
+  :port => 587,
+  :domain => 'smtp.gmail.com',
+  :user_name => ENV['GMAIL_ADDRESS'],
+  :password => ENV['GMAIL_PASSWORD'],
+  :authentication => 'login'
+}
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
・action mailerの本番環境用の設定を追加しました。

・メール送信用サーバーにはgmailを使用しています。
・パスワード再設定の際に使用します。